### PR TITLE
To let to separate elements by comma surrounded by whitespaces

### DIFF
--- a/common-ui-utils/src/main/java/com/griddynamics/qa/ui/steps/CommonPageSteps.java
+++ b/common-ui-utils/src/main/java/com/griddynamics/qa/ui/steps/CommonPageSteps.java
@@ -214,7 +214,7 @@ public class CommonPageSteps implements TimeoutConstants{
      */
     @Then("the links $links are displayed on page")
     public void isLinksDisplayed(String elements) {
-        String[] splits = elements.split(",");
+        String[] splits = elements.split("\\s*,\\s*");
         for (String element : splits) {
             assertTrue("[ERROR] Element " + element + " is not displayed",
                     pages.getCurrentPage().isElementDisplayedOnPage(element));


### PR DESCRIPTION
This let to separate elements by comma surrounded by whitespaces like "a , b, c" instead of strickly "a,b,c" now.
